### PR TITLE
Add public/data/*.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+public/data/*.json


### PR DESCRIPTION
This patch adds the json files in public/data/*.json to .gitignore to make it easier to update the application straight from git.