### PR TITLE
Try to find ping executable at runtime

### DIFF
--- a/public/class/Server.php
+++ b/public/class/Server.php
@@ -118,7 +118,7 @@ class Server {
 
     function getStatus() {
         $ip = $this->getValue($_POST['id'], "hostname");
-        exec("/usr/bin/ping -W 2 -c 3 $ip", $output, $status);
+        exec("`which ping` -W 2 -c 3 $ip", $output, $status);
         if ($status == 0) {
             return true;
         }


### PR DESCRIPTION
Currently, the `getStatus()` function relies on the `ping` executable being located in `/usr/bin/ping`. Some systems (e.g. Gentoo) use other paths like `/bin/ping` which breaks this function.

By using `which ping` instead, we could try to find the executable at runtime instead of hardcoding the file location.